### PR TITLE
Added command-line publish

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ typings/
 *.vsix
 *.docx
 dist
+commands/local.settings.js

--- a/README.md
+++ b/README.md
@@ -20,4 +20,4 @@
 - share is the name of the Azure DevOps account that you want to install (or have installed) the extension on.
 - token is a PAT with Marketplace Publish access.
 
-2. From a command line, run the command "npm run deploy".
+2. From a command line, run the command "npm run deploy". If you''ve already installed the extension, you can just refresh the page to see your changes.

--- a/README.md
+++ b/README.md
@@ -6,3 +6,18 @@
 2. npm install
 
 3. webpack && npm run package:dev 
+
+## Command-line deploy
+
+1. Add a .\commands\local.settings.js with the following contents (replacing the values as appropriate):
+  module.exports = {
+    publisher: "REPLACE",
+    share: "REPLACE",
+    token: "REPLACE"
+}
+
+- publisher is the name of the Azure DevOps Marketplace publisher.
+- share is the name of the Azure DevOps account that you want to install (or have installed) the extension on.
+- token is a PAT with Marketplace Publish access.
+
+2. From a command line, run the command "npm run deploy".

--- a/commands/local.settings.js
+++ b/commands/local.settings.js
@@ -1,0 +1,5 @@
+module.exports = {
+    publisher: "REPLACE",
+    share: "REPLACE",
+    token: "REPLACE"
+}

--- a/commands/local.settings.js
+++ b/commands/local.settings.js
@@ -1,5 +1,0 @@
-module.exports = {
-    publisher: "REPLACE",
-    share: "REPLACE",
-    token: "REPLACE"
-}

--- a/commands/packagePublish.js
+++ b/commands/packagePublish.js
@@ -1,0 +1,18 @@
+const exec = require("child_process").exec;
+
+const localSettings = require("./local.settings");
+
+const manifest = require("../vss-extension.json");
+const extensionId = manifest.id;
+const extensionVersion = manifest.version;
+
+const { publisher, share, token } = localSettings;
+const command = `tfx extension publish --extension-id ${extensionId}-dev --version ${extensionVersion} --publisher ${publisher} --share-with ${share} --token ${token}`;
+
+exec(command, function (error) {
+    if (error) {
+        console.log(`Package publish error: ${error}`);
+    } else {
+        console.log("Package created");
+    }
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -10320,9 +10320,9 @@
       "integrity": "sha512-U+JJi7duF1o+u2pynbp2zXDW2/PADgC30f0GsHZtRh+HOcXHnw137TrNlyxxRvWW5fjKd3bcLHPxofWuCjaeZg=="
     },
     "npm": {
-      "version": "6.9.0",
-      "resolved": "https://registry.npmjs.org/npm/-/npm-6.9.0.tgz",
-      "integrity": "sha512-91V+zB5hDxO+Jyp2sUKS7juHlIM95dGQxTeQtmZI1nAI/7kjWXFipPrtwwKjhyKmV4GsS2LzJhrxRjGWsU9z/w==",
+      "version": "6.9.2",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-6.9.2.tgz",
+      "integrity": "sha512-b0sEGRYrVdcV/DedLrqV4VMpdMHJbvpt9bopivh4K9RisHFMbj+G6RNbB6lRdr9rpYIoqHG9YP9CYmxdI9k81g==",
       "requires": {
         "JSONStream": "^1.3.5",
         "abbrev": "~1.1.1",
@@ -10412,21 +10412,21 @@
         "path-is-inside": "~1.0.2",
         "promise-inflight": "~1.0.1",
         "qrcode-terminal": "^0.12.0",
-        "query-string": "^6.2.0",
+        "query-string": "^6.4.0",
         "qw": "~1.0.1",
         "read": "~1.0.7",
         "read-cmd-shim": "~1.0.1",
         "read-installed": "~4.0.3",
         "read-package-json": "^2.0.13",
         "read-package-tree": "^5.2.2",
-        "readable-stream": "^3.1.1",
+        "readable-stream": "^3.2.0",
         "readdir-scoped-modules": "*",
         "request": "^2.88.0",
         "retry": "^0.12.0",
         "rimraf": "^2.6.3",
         "safe-buffer": "^5.1.2",
         "semver": "^5.6.0",
-        "sha": "~2.0.1",
+        "sha": "^3.0.0",
         "slide": "~1.1.6",
         "sorted-object": "~2.0.1",
         "sorted-union-stream": "~2.1.3",
@@ -12557,7 +12557,7 @@
           "bundled": true
         },
         "query-string": {
-          "version": "6.2.0",
+          "version": "6.4.0",
           "bundled": true,
           "requires": {
             "decode-uri-component": "^0.2.0",
@@ -12634,7 +12634,7 @@
           }
         },
         "readable-stream": {
-          "version": "3.1.1",
+          "version": "3.2.0",
           "bundled": true,
           "requires": {
             "inherits": "^2.0.3",
@@ -12753,33 +12753,10 @@
           "bundled": true
         },
         "sha": {
-          "version": "2.0.1",
+          "version": "3.0.0",
           "bundled": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "readable-stream": "^2.0.2"
-          },
-          "dependencies": {
-            "readable-stream": {
-              "version": "2.3.6",
-              "bundled": true,
-              "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.3",
-                "isarray": "~1.0.0",
-                "process-nextick-args": "~2.0.0",
-                "safe-buffer": "~5.1.1",
-                "string_decoder": "~1.1.1",
-                "util-deprecate": "~1.0.1"
-              }
-            },
-            "string_decoder": {
-              "version": "1.1.1",
-              "bundled": true,
-              "requires": {
-                "safe-buffer": "~5.1.0"
-              }
-            }
+            "graceful-fs": "^4.1.2"
           }
         },
         "shebang-command": {

--- a/package.json
+++ b/package.json
@@ -5,16 +5,18 @@
   "main": "webpack.config.js",
   "scripts": {
     "build": "webpack && npm run package:dev",
+    "deploy": "webpack && npm run package:dev && npm run package:publish",
     "package:dev": "node ./commands/packageDev",
+    "package:publish": "node ./commands/packagePublish",
     "dev:webpack": "webpack --watch",
-    "dev:http": "webpack-dev-server --progress --colors --content-base ./ --port 6666"
+    "dev:http": "webpack-dev-server --progress --colors --content-base ./ --port 3001"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "dependencies": {
     "es6-promise": "^4.2.4",
-    "npm": "^6.3.0",
+    "npm": "^6.9.2",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
     "react-router": "^5.0.1",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
     "compilerOptions": {
         "module": "amd",
         "sourceMap": true,
-        "noUnusedLocals": true,
+        "noUnusedLocals": false,
         "jsx": "react",
         "experimentalDecorators": true,
         "noFallthroughCasesInSwitch": true,


### PR DESCRIPTION
1. Add a .\commands\local.settings.js with the following contents (replacing the values as appropriate):
  module.exports = {
    publisher: "REPLACE",
    share: "REPLACE",
    token: "REPLACE"
}

- publisher is the name of the Azure DevOps Marketplace publisher.
- share is the name of the Azure DevOps account that you want to install (or have installed) the extension on.
- token is a PAT with Marketplace Publish access, *must select **All Accessible Organizations** in the Organization dropdown*.

2. From a command line, run the command "npm run deploy". If you''ve already installed the extension, you can just refresh the page to see your changes.