### PR TITLE
Revert identity on cancel edit

### DIFF
--- a/src/AreaPanel/AddAreaPanel.scss
+++ b/src/AreaPanel/AddAreaPanel.scss
@@ -6,11 +6,9 @@
        flex-direction: column;
 
        .area-form-fields {
-           flex: 1;
 
-           .area-form-name{
-               margin-top: 8px;
-               margin-bottom: 8px;
+           .area-field {
+               margin-top: 8px; 
            }
        }
 

--- a/src/AreaPanel/AddAreaPanel.tsx
+++ b/src/AreaPanel/AddAreaPanel.tsx
@@ -3,6 +3,8 @@ import { Panel } from "azure-devops-ui/Panel";
 import { StateContext, IOKRContext } from '../StateMangement/StateProvider';
 import AreaForm from "./AreaForm";
 import "./AddAreaPanel.scss";
+import { IPeoplePickerProvider } from "azure-devops-ui/IdentityPicker";
+import { IdentityProvider } from "../Identity/IdentityProvider";
 
 interface IAddAreaPanelState {
     expanded: boolean;
@@ -10,6 +12,8 @@ interface IAddAreaPanelState {
 
 export class AddAreaPanel extends React.Component<{}, IAddAreaPanelState> {
     static contextType = StateContext;
+
+    private identityProvider: IPeoplePickerProvider = new IdentityProvider();
 
     public render(): JSX.Element {
         const stateContext = this.context as IOKRContext;
@@ -26,7 +30,7 @@ export class AddAreaPanel extends React.Component<{}, IAddAreaPanelState> {
                         titleProps={{ text: "Add Product Area" }}
                     >
                         <div className="panel-content">
-                            <AreaForm />
+                            <AreaForm identityProvider={this.identityProvider}/>
                         </div>
                     </Panel>
                 )}

--- a/src/AreaPanel/AreaForm.tsx
+++ b/src/AreaPanel/AreaForm.tsx
@@ -4,30 +4,46 @@ import { Button } from "azure-devops-ui/Button";
 import { ButtonGroup } from "azure-devops-ui/ButtonGroup";
 import { TextField } from "azure-devops-ui/TextField";
 import { Guid } from "guid-typescript";
+import { AreaCardIdentity } from "../AreaView/AreaCard/AreaCardIdentity";
+import { IPeoplePickerProvider } from "azure-devops-ui/IdentityPicker";
+
+export interface IAreaFormProps {
+    identityProvider: IPeoplePickerProvider;
+}
 
 export interface IAreaFormState {
     name: string;
     description: string;
+    ownerId: string;
+    ownerName: string;
 }
 
-export default class AreaForm extends React.Component<{}, IAreaFormState> {
+export default class AreaForm extends React.Component<IAreaFormProps, IAreaFormState> {
     static contextType = StateContext;
     constructor(props) {
         super(props)
         this.state = {
             name: "",
             description: "",
+            ownerId: undefined,
+            ownerName: undefined,
         }
     }
 
     public render(): JSX.Element {
         const stateContext = this.context as IOKRContext;
-        const { name, description } = this.state
+        const { name, description } = this.state;
+        const { identityProvider } = this.props;
+
+        const updateOwnerState = (updatedOwnerId: string, updatedOwnerName: string) => {
+            this.setState({ ownerId: updatedOwnerId, ownerName: updatedOwnerName });
+        }
+
         return (
             <>
                 <div className="area-form-fields">
                     <TextField
-                        className="area-form-name"
+                        className="area-field"
                         placeholder="Product Area"
                         value={name}
                         onChange={(e, newValue) => {
@@ -35,13 +51,17 @@ export default class AreaForm extends React.Component<{}, IAreaFormState> {
                         }}
                     />
                     <TextField
-                        className="area-form-description"
+                        className="area-field"
                         placeholder="Description"
                         value={description}
+                        multiline={true}
                         onChange={(e, newValue) => {
                             this.setState({ description: newValue });
                         }}
                     />
+                    <div className={"area-field"}>
+                        <AreaCardIdentity area={{} as any} identityProvider={identityProvider} editMode={true} updateDraftOwner={updateOwnerState} />
+                    </div>
                 </div>
                 <div className="area-form-submit">
                     <ButtonGroup>
@@ -56,10 +76,11 @@ export default class AreaForm extends React.Component<{}, IAreaFormState> {
                                 Description: this.state.description,
                                 Version: 0,
                                 AreaId: Guid.create().toString(),
-                                OwnerId: "",
+                                OwnerId: this.state.ownerId ? this.state.ownerId : "",
+                                OwnerName: this.state.ownerName ? this.state.ownerName : ""
                             }
 
-                        stateContext.actions.createArea(toBeCreated)
+                            stateContext.actions.createArea(toBeCreated)
 
                         }} />
                     </ButtonGroup>

--- a/src/AreaView/AreaCard/AreaCard.tsx
+++ b/src/AreaView/AreaCard/AreaCard.tsx
@@ -12,7 +12,7 @@ import { NavigationConstants } from "../../OKRConstants";
 
 export interface IAreaCardProps {
     area: Area;
-    identityProvider: IPeoplePickerProvider;    
+    identityProvider: IPeoplePickerProvider;
 }
 
 export const AreaCard: React.FunctionComponent<IAreaCardProps> = props => {
@@ -57,7 +57,12 @@ export const AreaCard: React.FunctionComponent<IAreaCardProps> = props => {
     const save = () => {
         // save before you toggle edit mode. Toggling edit will clear the draft. 
         stateContext.actions.editArea(draftArea);
-        toggleEditMode();
+        
+        // Setting a timeout on closing the edit mode so that edit area has a chance to complete
+        // This is to avoid a flash on completion 
+        setTimeout(() => {
+            toggleEditMode();
+        }, 200);
     }
 
     const removeAreaCallback = (): void => {
@@ -74,8 +79,8 @@ export const AreaCard: React.FunctionComponent<IAreaCardProps> = props => {
         }
 
         var element = e.target;
-        while(element && !element.classList.contains("area-grid")) {
-            if (element.classList.contains("area-context-menu") 
+        while (element && !element.classList.contains("area-grid")) {
+            if (element.classList.contains("area-context-menu")
                 || element.classList.contains("bolt-callout")) {
                 e.stopPropagation();
                 return;

--- a/src/AreaView/AreaCard/AreaCard.tsx
+++ b/src/AreaView/AreaCard/AreaCard.tsx
@@ -1,15 +1,17 @@
 import * as React from "react";
 import { Area } from "../../Area/Area";
 import { Card } from "azure-devops-ui/Card";
-import { Splitter, SplitterElementPosition } from "azure-devops-ui/Splitter";
 import { IPeoplePickerProvider } from "azure-devops-ui/IdentityPicker";
 import "../AreaView.scss";
 import { AreaCardIdentity } from "./AreaCardIdentity";
 import { AreaCardDetails } from "./Details/AreaCardDetails";
 import { Dialog } from "azure-devops-ui/Dialog";
+import { useStateValue } from "../../StateMangement/StateProvider";
+import produce from "immer";
+import { AreaCardButtons } from "./AreaCardButtons";
 
 export interface IAreaCardProps {
-    area: Area;    
+    area: Area;
     identityProvider: IPeoplePickerProvider;
     removeAreaCallback: (id: string, areaId: string) => void;
     onCardClick: (area: Area) => void;
@@ -17,32 +19,61 @@ export interface IAreaCardProps {
 
 export const AreaCard: React.FunctionComponent<IAreaCardProps> = props => {
     const { area, identityProvider, removeAreaCallback, onCardClick } = props;
-    const [{ editMode, isDialogOpen }, localDispatcher] = React.useState({ editMode: false, isDialogOpen: false });
+    const [{ editMode, isDialogOpen, draftArea }, localDispatcher] = React.useState({ editMode: false, isDialogOpen: false, draftArea: undefined });
+    const stateContext = useStateValue();
 
     const toggleEditMode = () => {
-        localDispatcher({ editMode: !editMode, isDialogOpen: isDialogOpen });
+        // If starting to edit, set the draft to the passed in area. 
+        // If exiting editing, clear the draft. 
+        const exitingEditMode = editMode;
+        let newDraftArea = exitingEditMode ? undefined : area;
+
+        localDispatcher({ editMode: !editMode, isDialogOpen: isDialogOpen, draftArea: newDraftArea });
     };
 
-    const setDialogState = (dialogStatus: boolean) => {
-        localDispatcher({ editMode: editMode, isDialogOpen: dialogStatus });
+    const setDeleteDialogState = (dialogStatus: boolean) => {
+        localDispatcher({ editMode: editMode, isDialogOpen: dialogStatus, draftArea: draftArea });
     };
 
-    const onRenderFarElement = (identityProvider: IPeoplePickerProvider, ownerId: string, editMode: boolean) => {
-        return <AreaCardIdentity area={area} identityProvider={identityProvider} editMode={editMode} />;
-    };
+    const updateOwner = (ownerId: string, ownerName: string) => {
+        const newArea = produce(draftArea, draft => {
+            draft.OwnerId = ownerId;
+            draft.OwnerName = ownerName;
+        })
 
-    const onRenderNearElement = (area, editMode: boolean, toggleEditMode: () => void) => {
-        return <AreaCardDetails area={area} editMode={editMode} toggleEditMode={toggleEditMode} setDialogState={setDialogState} />;
-    };
+        localDispatcher({ editMode: editMode, isDialogOpen: isDialogOpen, draftArea: newArea });
+    }
+
+    const updateName = (name: string) => {
+        const newArea = produce(draftArea, draft => {
+            draft.Name = name;
+        })
+
+        localDispatcher({ editMode: editMode, isDialogOpen: isDialogOpen, draftArea: newArea });
+    }
+
+    const updateDescription = (description: string) => {
+        const newArea = produce(draftArea, draft => {
+            draft.Description = description;
+        })
+
+        localDispatcher({ editMode: editMode, isDialogOpen: isDialogOpen, draftArea: newArea });
+    }
+
+    const save = () => {
+        // save before you toggle edit mode. Toggling edit will clear the draft. 
+        stateContext.actions.editArea(draftArea);
+        toggleEditMode();
+    }
 
     const onClickCard = (e) => {
         if (editMode) {
             e.stopPropagation();
             return;
         }
-        
+
         var element = e.target;
-        while(!element.classList.contains("area-grid")) {
+        while (!element.classList.contains("area-grid")) {
             if (element.classList.contains("area-context-menu")) {
                 e.stopPropagation();
                 return;
@@ -52,42 +83,36 @@ export const AreaCard: React.FunctionComponent<IAreaCardProps> = props => {
         onCardClick(area);
     }
 
+    const buttons = <AreaCardButtons toggleEditMode={toggleEditMode} save={save} editMode={editMode} setDeleteDialogState={setDeleteDialogState} />;
+
     return (<div onClick={onClickCard}>
         <Card className="area-card">
-            <Splitter
-                fixedElement={SplitterElementPosition.Far}
-                fixedSize={64}
-                splitterDirection={1}
-                onRenderNearElement={() => onRenderNearElement(area, editMode, toggleEditMode)}
-                onRenderFarElement={() => onRenderFarElement(identityProvider, area.OwnerId, editMode)}
-                nearElementClassName="area-details"
-                disabled={true}
-            />
-            {isDialogOpen &&
-                <Dialog
-                    titleProps={{ text: "Delete Area" }}
-                    footerButtonProps={[
-                        {
-                            text: "Cancel",
-                            onClick: () => {
-                                setDialogState(false);
+            <div className="area-card-interior">
+                <AreaCardDetails area={area} draftArea={draftArea} editMode={editMode} updateDraftName={updateName} updateDraftDescription={updateDescription} buttons={buttons} />
+                <AreaCardIdentity area={editMode? draftArea: area} identityProvider={identityProvider} editMode={editMode} updateDraftOwner={updateOwner} />
+                {isDialogOpen &&
+                    <Dialog
+                        titleProps={{ text: "Delete Area" }}
+                        footerButtonProps={[
+                            {
+                                text: "Cancel",
+                                onClick: () => {
+                                    setDeleteDialogState(false);
+                                }
+                            },
+                            {
+                                text: "OK", primary: true, onClick: () => {
+                                    removeAreaCallback(area.id, area.AreaId);
+                                    setDeleteDialogState(false);
+                                }
                             }
-                        },
-                        {
-                            text: "OK", primary: true, onClick: () => {
-                                removeAreaCallback(area.id, area.AreaId);
-                                setDialogState(false);
-                            }
-                        }
-                    ]}
-                    onDismiss={() => {
-                        setDialogState(false);
-                    }}>
-                    {"Are you sure to delete this area?"}
-                </Dialog>}
+                        ]}
+                        onDismiss={() => {
+                            setDeleteDialogState(false);
+                        }}>
+                        {"Are you sure to delete this area?"}
+                    </Dialog>}
+            </div>
         </Card>
     </div>);
 }
-
-
-

--- a/src/AreaView/AreaCard/AreaCardButtons.tsx
+++ b/src/AreaView/AreaCard/AreaCardButtons.tsx
@@ -37,15 +37,15 @@ export const AreaCardButtons: React.FunctionComponent<IAreaCardButtons> = props 
 function renderEditButtons(toggleEditMode: Function, save: Function): JSX.Element {
     return <div className="edit-buttons">
         <Button
-            onClick={() => { save() }}
-            ariaLabel="Save button"
-            iconProps={{ iconName: "CheckMark" }}
-            subtle={true}
-        />
-        <Button
             onClick={() => toggleEditMode()}
             ariaLabel="Cancel button"
             iconProps={{ iconName: "Cancel" }}
+            subtle={true}
+        />
+        <Button
+            onClick={() => { save() }}
+            ariaLabel="Save button"
+            iconProps={{ iconName: "CheckMark" }}
             subtle={true}
         />
     </div>;

--- a/src/AreaView/AreaCard/AreaCardButtons.tsx
+++ b/src/AreaView/AreaCard/AreaCardButtons.tsx
@@ -1,0 +1,64 @@
+import * as React from "react";
+import "../AreaView.scss";
+import { IMenuItem, MenuButton } from "azure-devops-ui/Menu";
+import { Button } from "azure-devops-ui/Button";
+
+export interface IAreaCardButtons {
+    editMode: boolean;
+    toggleEditMode: () => void;
+    setDeleteDialogState: (state: boolean) => void;
+    save: () => void;
+}
+
+export const AreaCardButtons: React.FunctionComponent<IAreaCardButtons> = props => {
+    const { editMode, toggleEditMode, setDeleteDialogState: setDialogState, save } = props;
+
+    return editMode ?
+        renderEditButtons(toggleEditMode, save) :
+        renderStaticButtons(toggleEditMode, setDialogState);
+}
+
+function renderEditButtons(toggleEditMode, save: Function): JSX.Element {
+    return <div className="edit-buttons">
+        <Button
+            onClick={() => { save() }}
+            ariaLabel="Save button"
+            iconProps={{ iconName: "CheckMark" }}
+            subtle={true}
+        />
+        <Button
+            onClick={toggleEditMode}
+            ariaLabel="Cancel button"
+            iconProps={{ iconName: "Cancel" }}
+            subtle={true}
+        />
+    </div>;
+}
+
+function renderStaticButtons(toggleEditMode, setDeleteDialogState) {
+    const getButtons = (toggleEditMode: () => void): IMenuItem[] => {
+        return [
+            {
+                id: "edit-button",
+                text: "Edit",
+                iconProps: { iconName: "Edit" },
+                onActivate: toggleEditMode
+            },
+            {
+                id: "delete-button",
+                text: "Delete",
+                iconProps: { iconName: "Delete" },
+                onActivate: () => {
+                    setDeleteDialogState(true);
+                }
+            }
+        ];
+    }
+
+    return <div className="area-context-menu"><MenuButton hideDropdownIcon={true} contextualMenuProps={{ menuProps: { id: "editButtons", items: getButtons(toggleEditMode) } }} iconProps={{ iconName: "More" }} /></div>;
+}
+
+
+
+
+

--- a/src/AreaView/AreaCard/AreaCardIdentity.tsx
+++ b/src/AreaView/AreaCard/AreaCardIdentity.tsx
@@ -1,17 +1,16 @@
 import * as React from "react";
 import { IPeoplePickerProvider, IIdentity, IdentityPickerDropdown } from "azure-devops-ui/IdentityPicker";
-import { useStateValue, IOKRContext } from "../../StateMangement/StateProvider";
 import { Area } from "../../Area/Area";
 
 export interface IAreaCardIdentityProps {
     area: Area;
     identityProvider: IPeoplePickerProvider;
     editMode: boolean;
+    updateDraftOwner: (udpatedOwnerId: string, updatedOwnerName: string) => void;
 }
 
 export const AreaCardIdentity: React.FunctionComponent<IAreaCardIdentityProps> = props => {
-    const { identityProvider, area, editMode } = props;
-    const stateContext = useStateValue();
+    const { identityProvider, area, editMode, updateDraftOwner } = props;    
     const [{ done, selected }, localDispatch] = React.useState({ done: false, selected: undefined });
 
     React.useEffect(() => {
@@ -34,7 +33,7 @@ export const AreaCardIdentity: React.FunctionComponent<IAreaCardIdentityProps> =
 
     if (done) {
         return <div className="area-identity">
-            {editMode ? renderPicker(stateContext, identityProvider, area, selected) : renderStatic(area)}
+            {editMode ? renderPicker(updateDraftOwner, identityProvider, selected) : renderStatic(area)}
         </div>;
     } else {
         return <div />
@@ -45,20 +44,17 @@ function renderStatic(area: Area): JSX.Element {
     return <div>{area.OwnerName || "unassigned"}</div>;
 };
 
-function renderPicker(stateContext: IOKRContext, identityProvider: IPeoplePickerProvider, area: Area, selected: IIdentity): JSX.Element {
+function renderPicker(updateOwnerCallback: Function, identityProvider: IPeoplePickerProvider, selected: IIdentity): JSX.Element {
     return <IdentityPickerDropdown
-        onChange={(identity?: IIdentity) => onChange(stateContext, area, identity)}
+        onChange={(identity?: IIdentity) => onChange(updateOwnerCallback, identity)}
         pickerProvider={identityProvider}
         value={selected}
     />;
 };
 
-function onChange(stateContext: IOKRContext, area: Area, identity?: IIdentity) {
-    const newArea = {
-        ...area,
-        OwnerId: identity ? identity.entityId : undefined,
-        OwnerName: identity ? identity.displayName : undefined,
-    };
+function onChange(updateOwnerCallback: Function, identity?: IIdentity) {
+    let ownerId = identity ? identity.entityId : undefined;
+    let ownerName = identity ? identity.displayName : undefined;
 
-    stateContext.actions.editArea(newArea);
+    updateOwnerCallback(ownerId, ownerName);     
 };

--- a/src/AreaView/AreaCard/AreaCardProgress.tsx
+++ b/src/AreaView/AreaCard/AreaCardProgress.tsx
@@ -18,7 +18,7 @@ export const AreaCardProgress: React.FunctionComponent<IAreaCardProgressProps> =
 				lineWidth={"50"}
 				progressColor={"rgb(0, 200, 100)"}
 				animate={false}
-				roundedStroke={false}
+				bgColor={"rgb(201, 201, 201)"}	
 			/>
 		</span>
 	</div>;

--- a/src/AreaView/AreaCard/Details/AreaCardDetails.tsx
+++ b/src/AreaView/AreaCard/Details/AreaCardDetails.tsx
@@ -8,20 +8,22 @@ import { getObjectivesForArea } from "../../../StateMangement/OKRSelector";
 
 export interface IAreaCardDetailsProps {
 	area: Area;
+	draftArea: Area; 
 	editMode: boolean;
-	toggleEditMode: () => void;
-	setDialogState: (dialogStatus: boolean) => void;
+	updateDraftName: (name: string) => void;
+	updateDraftDescription: (description: string) => void;
+	buttons: JSX.Element; 
 }
 
 export const AreaCardDetails: React.FunctionComponent<IAreaCardDetailsProps> = props => {
 	const stateContext = useStateValue();
 
-	const { area, editMode, toggleEditMode, setDialogState } = props;
+	const { area, draftArea, editMode, updateDraftDescription, updateDraftName, buttons } = props;
 	const objectives = getObjectivesForArea(stateContext.state, area); 
 
 	return (
 		<div className="area-card-details">
-			{editMode ? <AreaCardDetailsEdit area={props.area} toggleEditMode={toggleEditMode} /> : <AreaCardDetailsStatic area={props.area} toggleEditMode={toggleEditMode} setDialogState={setDialogState}/>}
+			{editMode ? <AreaCardDetailsEdit draftArea={draftArea} updateDraftName={updateDraftName} updateDraftDescription={updateDraftDescription} buttons={buttons} /> : <AreaCardDetailsStatic area={area} buttons={buttons}/>}
 			<h4>{`${objectives.length} objectives`}</h4>
 			<AreaCardProgress objectives={objectives} />
 		</div>

--- a/src/AreaView/AreaCard/Details/AreaCardDetailsEdit.tsx
+++ b/src/AreaView/AreaCard/Details/AreaCardDetailsEdit.tsx
@@ -4,50 +4,22 @@ import { useStateValue, IOKRContext } from "../../../StateMangement/StateProvide
 import { Area } from "../../../Area/Area";
 
 export interface IAreaCardDetailsEditProps {
-	area: Area,
-	toggleEditMode: () => void;
+	draftArea: Area,
+	buttons: JSX.Element; 
+	updateDraftName: (name: string) => void;
+	updateDraftDescription: (description: string) => void;
 }
 
 export const AreaCardDetailsEdit: React.FunctionComponent<IAreaCardDetailsEditProps> = props => {
-	const stateContext = useStateValue();
-	const [{ editName, editDescription }, localDispatcher] = React.useState({ editName: props.area.Name, editDescription: props.area.Description});
+	const { draftArea, buttons, updateDraftName, updateDraftDescription } = props;		
 
 	return <>
 		<div className="card-header">
 			<h3>
-				<input value={editName} onChange={(val) => { localDispatcher({ editName: val.target.value, editDescription})}} />
-			</h3>
-			{renderEditButtons(props.area, editName, editDescription, props.toggleEditMode, stateContext)}
+				<input value={draftArea.Name} onChange={(val) => { updateDraftName(val.target.value) }} />
+			</h3>			
+			{buttons}
 		</div>
-		<input value={editDescription} onChange={(val) => { localDispatcher({ editName, editDescription: val.target.value})}} />
+		<input value={draftArea.Description} onChange={(val) => {updateDraftDescription(val.target.value) }} />
 	</>;
 };
-
-function renderEditButtons(area, editName, editDescription, toggleEditMode, stateContext: IOKRContext): JSX.Element {
-	return <div className="edit-buttons">
-		<Button
-			onClick={() => save(area, editName, editDescription, toggleEditMode, stateContext)}
-			ariaLabel="Save button"
-			iconProps={{ iconName: "CheckMark" }}
-			subtle={true}
-		/>
-		<Button
-			onClick={toggleEditMode}
-			ariaLabel="Cancel button"
-			iconProps={{ iconName: "Cancel" }}
-			subtle={true}
-		/>
-	</div>;
-}
-
-function save(area, editName, editDescription, toggleEditMode, stateContext: IOKRContext): void {
-	const newArea = {
-		...area,
-		Name: editName,
-		Description: editDescription,
-	};
-
-	stateContext.actions.editArea(newArea);
-
-	toggleEditMode();
-}

--- a/src/AreaView/AreaCard/Details/AreaCardDetailsStatic.tsx
+++ b/src/AreaView/AreaCard/Details/AreaCardDetailsStatic.tsx
@@ -1,39 +1,18 @@
 import * as React from "react";
-import { MenuButton, IMenuItem } from "azure-devops-ui/Menu";
 import { Area } from "../../../Area/Area";
 
 export interface IAreaCardDetailsStaticProps {
 	area: Area;
-	toggleEditMode: () => void;
-	setDialogState: (dialogStatus: boolean) => void;
+	buttons: JSX.Element;
 }
 
 export const AreaCardDetailsStatic: React.FunctionComponent<IAreaCardDetailsStaticProps> = props => {
-	const { area, toggleEditMode, setDialogState } = props;
-
-	const getButtons = (toggleEditMode: () => void): IMenuItem[] => {
-		return [
-			{
-				id: "edit-button",
-				text: "Edit",
-				iconProps: { iconName: "Edit" },
-				onActivate: toggleEditMode
-			},
-			{
-				id: "delete-button",
-				text: "Delete",
-				iconProps: { iconName: "Delete" },
-				onActivate: () => { 
-					setDialogState(true);
-				}
-			}
-		];
-	}
+	const { area, buttons } = props;
 
 	return <>
 		<div className="card-header">
 			<h3><div className="area-name-title">{area.Name}</div></h3>
-			<div className="area-context-menu"><MenuButton hideDropdownIcon={true} contextualMenuProps={{ menuProps: { id: "test", items: getButtons(toggleEditMode) } }} iconProps={{ iconName: "More" }} /></div>
+			{buttons}
 		</div>
 		<p>{area.Description}</p>
 	</>;

--- a/src/AreaView/AreaGrid.tsx
+++ b/src/AreaView/AreaGrid.tsx
@@ -7,8 +7,6 @@ import { AreaZeroData } from "./AreaZeroData";
 
 export interface IAreaGridProps {
     areas: Area[];    
-    removeAreaCallback: (id: string, areaId: string) => void;
-    onCardClick: (area: Area) => void;
 }
 
 export class AreaGrid extends React.Component<IAreaGridProps> {
@@ -24,9 +22,7 @@ export class AreaGrid extends React.Component<IAreaGridProps> {
                     <AreaCard
                         area={area}                        
                         identityProvider={this.identityProvider}
-                        key={index}
-                        removeAreaCallback={this.props.removeAreaCallback}
-                        onCardClick={this.props.onCardClick}
+                        key={index}                                                
                     />
                 )}
             </div>

--- a/src/AreaView/AreaView.scss
+++ b/src/AreaView/AreaView.scss
@@ -25,25 +25,23 @@
 			background: #F8F8F8;
 		}
 
-		.area-card-interior {		
-			width: 380px;
-			cursor: pointer;
+		.area-card-interior {			
 			flex-direction: column;
 
 			.area-card-details{
-			display: flex;
-			flex-direction: column;
+				display: flex;
+				flex-direction: column;
 
 			.card-header{
-					display: flex; 
-					justify-content: space-between; 
-					margin-bottom: 0px;
-					align-items: baseline;
+				display: flex; 
+				justify-content: space-between; 
+				margin-bottom: 0px;
+				align-items: baseline;
 
-					.flex-column {
-						flex: 1;
-					}
+				.flex-column {
+					flex: 1;
 				}
+			}
 
 				.area-name-title:hover{
 					cursor: pointer;

--- a/src/AreaView/AreaView.scss
+++ b/src/AreaView/AreaView.scss
@@ -32,16 +32,16 @@
 				display: flex;
 				flex-direction: column;
 
-			.card-header{
-				display: flex; 
-				justify-content: space-between; 
-				margin-bottom: 0px;
-				align-items: baseline;
+				.card-header{
+					display: flex; 
+					justify-content: space-between; 
+					margin-bottom: 0px;
+					align-items: baseline;
 
-				.flex-column {
-					flex: 1;
+					.flex-column {
+						flex: 1;
+					}
 				}
-			}
 
 				.area-name-title:hover{
 					cursor: pointer;

--- a/src/AreaView/AreaView.scss
+++ b/src/AreaView/AreaView.scss
@@ -27,6 +27,7 @@
 
 		.area-card-interior {			
 			flex-direction: column;
+			width: 100%;
 
 			.area-card-details{
 				display: flex;

--- a/src/AreaView/AreaView.scss
+++ b/src/AreaView/AreaView.scss
@@ -5,6 +5,8 @@
 		display: flex;
 		flex-wrap: wrap; 
 		width: 100%;
+
+		padding: 15px; 
 	}
 
 	.okr-error-message{
@@ -14,25 +16,22 @@
 		}
 	}
 
-	.area-card {
-		margin: 8px;
-		width: 380px;
-		cursor: pointer;
-
+	.area-card {		
+		
 		&:hover {
 			background: #F8F8F8;
 		}
 
-		.area-details {
-			display: flex;
+		.area-card-interior {		
+			width: 380px;
+			cursor: pointer;
 			flex-direction: column;
-			width: 100%;
 
 			.area-card-details{
-				display: flex;
-				flex-direction: column;
+			display: flex;
+			flex-direction: column;
 
-				.card-header{
+			.card-header{
 					display: flex; 
 					justify-content: space-between; 
 					margin-bottom: 0px;
@@ -63,7 +62,8 @@
 		}
 
 		.area-identity {
-			margin-top: 20px;
+			padding-top: 20px;
+			border-top: 1px solid lightgray; 			
 		}
 	}
 }

--- a/src/AreaView/AreaView.scss
+++ b/src/AreaView/AreaView.scss
@@ -6,7 +6,7 @@
 		flex-wrap: wrap; 
 		width: 100%;
 
-		padding: 15px; 
+		padding: 10px; 
 	}
 
 	.okr-error-message{
@@ -17,9 +17,10 @@
 	}
 
 	.area-card {
+		margin: 8px;
 		width: 380px;
 		height: 350px;
-		cursor: pointer;
+		cursor: pointer;		
 
 		&:hover {
 			background: #F8F8F8;

--- a/src/AreaView/AreaView.tsx
+++ b/src/AreaView/AreaView.tsx
@@ -4,8 +4,6 @@ import { Header } from "azure-devops-ui/Header";
 import { IHeaderCommandBarItem } from "azure-devops-ui/HeaderCommandBar";
 import { AddAreaPanel } from '../AreaPanel/AddAreaPanel';
 import { useStateValue } from "../StateMangement/StateProvider";
-import { NavigationConstants } from "../OKRConstants";
-import { Area } from "../Area/Area";
 import { ErrorMessage } from "../ErrorMessage";
 
 export const AreaView: React.FunctionComponent<{}> = props => {
@@ -14,16 +12,6 @@ export const AreaView: React.FunctionComponent<{}> = props => {
     const dismissError = (): void => {
         stateContext.actions.setError({error: undefined});
     }; 
-    const removeAreaCallback = (id: string, areaId: string): void => {
-        stateContext.actions.removeArea({
-            id: id,
-            areaId: areaId
-        });
-    };
-
-    const onCardClick = (area: Area): void => {
-        stateContext.actions.navigatePage({ pageLocation: NavigationConstants.DetailView, selectedArea: area });
-    };
 
     const commandBarItems: IHeaderCommandBarItem[] = [
         {
@@ -60,7 +48,7 @@ export const AreaView: React.FunctionComponent<{}> = props => {
                 />
                 <ErrorMessage onDismiss={dismissError} error={stateContext.state.error} />
                 <AddAreaPanel />
-                <AreaGrid areas={stateContext.state.areas} removeAreaCallback={removeAreaCallback} onCardClick={onCardClick}/>
+                <AreaGrid areas={stateContext.state.areas} />
             </div>
     }
 

--- a/src/DetailView/KRComment.tsx
+++ b/src/DetailView/KRComment.tsx
@@ -27,7 +27,7 @@ export class KRComment extends React.Component<IKRCommentProps, IKRCommentState>
             {isEditMode ? (<div>
                 <TextField
                     value={this.state.value}
-                    placeholder="Add Note"
+                    placeholder="Add note to describe current status of OKR"
                     multiline={true}
                     autoFocus={true}
                     onChange={(e, newValue) => {

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -2,11 +2,7 @@
     "manifestVersion": 1,
     "id": "okr-hub",
     "publisher": "nianwensong",
-<<<<<<< HEAD
-    "version": "1.0.393",
-=======
     "version": "1.0.623",
->>>>>>> origin/master
     "name": "OKR Hub",
     "description": "",
     "public": false,


### PR DESCRIPTION
#81 Refactored the state of the Area Card so that identity can be reverted when the operation is canceled. 

`<AreaCard>` - Parent component. Its the smart component that manages a draft state when we are editing. It passes callbacks to the Detail and Identity components that they call to update draftState when their values are changed.  When the user presses save, it fires the editArea action with its draft state. It also manages the the state of editing or not. 
`<AreaCardButtons>` Single source for buttons. It is told by AreaCard if it is in edit mode or not, and has a callback to toggle the state. Buttons are then passed (as a jsx) to the `<AreaCardDetail>` so that they can be rendered alongside the header. This is the best way to render the div next to the Title so they show on the same line. 

I removed the splitter component and replaced it with a top border on the identity picker. 